### PR TITLE
feat: allow schema definitions in #/components/schemas

### DIFF
--- a/examples/server.ts
+++ b/examples/server.ts
@@ -199,6 +199,7 @@ const document = openApiBuilder({
   version: "1.0.0",
   description: "A simple user API",
 })
+  .addDefinitions({ user: userSchema, comment: commentSchema })
   .addServer({ url: "/api/v1" })
   .addSecurityScheme("admin", bearerAuthScheme())
   .addPublicApi(api)

--- a/package.json
+++ b/package.json
@@ -61,6 +61,6 @@
   },
   "dependencies": {
     "openapi-types": "12.1.3",
-    "zod-to-json-schema": "3.19.1"
+    "zod-to-json-schema": "3.21.4"
   }
 }

--- a/src/__snapshots__/openapi.test.ts.snap
+++ b/src/__snapshots__/openapi.test.ts.snap
@@ -1555,6 +1555,309 @@ exports[`toOpenApi should convert to openapi with builder 1`] = `
 }
 `;
 
+exports[`toOpenApi should convert to openapi with builder using definitions 1`] = `
+{
+  "components": {
+    "schemas": {
+      "user": {
+        "additionalProperties": false,
+        "properties": {
+          "email": {
+            "format": "email",
+            "type": "string",
+          },
+          "id": {
+            "type": "string",
+          },
+          "name": {
+            "type": "string",
+          },
+        },
+        "required": [
+          "id",
+          "name",
+          "email",
+        ],
+        "type": "object",
+      },
+    },
+  },
+  "info": {
+    "title": "My API",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.0",
+  "paths": {
+    "/users": {
+      "post": {
+        "description": "Create a user",
+        "operationId": "createUser",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "email": {
+                    "$ref": "#/components/schemas/user/properties/email",
+                  },
+                  "name": {
+                    "$ref": "#/components/schemas/user/properties/name",
+                  },
+                },
+                "required": [
+                  "name",
+                  "email",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "description": "The user to create",
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/user",
+                },
+              },
+            },
+            "description": "Success",
+          },
+        },
+        "security": undefined,
+        "summary": "Create a user",
+        "tags": [
+          "users",
+        ],
+      },
+    },
+    "/users/{id}": {
+      "delete": {
+        "description": "Delete a user",
+        "operationId": "deleteUser",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": undefined,
+        "responses": {
+          "204": {
+            "content": {
+              "application/json": {
+                "schema": undefined,
+              },
+            },
+            "description": "Success",
+          },
+        },
+        "security": undefined,
+        "summary": "Delete a user",
+        "tags": [
+          "users",
+        ],
+      },
+      "get": {
+        "description": "Get a user by id",
+        "operationId": "getUser",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": undefined,
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/user",
+                },
+              },
+            },
+            "description": "Success",
+          },
+        },
+        "security": undefined,
+        "summary": "Get a user by id",
+        "tags": [
+          "users",
+        ],
+      },
+      "put": {
+        "description": "Update a user",
+        "operationId": "updateUser",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/user",
+              },
+            },
+          },
+          "description": "The user to update",
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/user",
+                },
+              },
+            },
+            "description": "Success",
+          },
+        },
+        "security": undefined,
+        "summary": "Update a user",
+        "tags": [
+          "users",
+        ],
+      },
+    },
+    "/users?filter={filter}#fragment": {
+      "get": {
+        "description": "Get all users",
+        "operationId": "getUsers",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "filter",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "description": "Limit the number of users",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "exclusiveMinimum": true,
+              "minimum": 0,
+              "type": "number",
+            },
+          },
+          {
+            "description": "Offset the number of users",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "exclusiveMinimum": true,
+              "minimum": 0,
+              "type": "number",
+            },
+          },
+          {
+            "description": "Filter users by name",
+            "in": "query",
+            "name": "filter[]",
+            "required": true,
+            "schema": {
+              "items": {
+                "type": "string",
+              },
+              "type": "array",
+            },
+          },
+        ],
+        "requestBody": undefined,
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/user",
+                  },
+                  "type": "array",
+                },
+              },
+            },
+            "description": "Success",
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "message": {
+                      "enum": [
+                        "No users found",
+                      ],
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "message",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "No users found",
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "message",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Default error",
+          },
+        },
+        "security": undefined,
+        "summary": "Get all users",
+        "tags": [
+          "users",
+        ],
+      },
+    },
+  },
+  "servers": undefined,
+}
+`;
+
 exports[`toOpenApi should convert to openapi with builder with security 1`] = `
 {
   "components": {

--- a/src/openapi.test.ts
+++ b/src/openapi.test.ts
@@ -236,4 +236,15 @@ describe("toOpenApi", () => {
       .build();
     expect(openApi).toMatchSnapshot();
   });
+
+  it("should convert to openapi with builder using definitions", () => {
+    const openApi = openApiBuilder({
+      title: "My API",
+      version: "1.0.0",
+    })
+      .addPublicApi(api)
+      .addDefinitions({ user })
+      .build();
+    expect(openApi).toMatchSnapshot();
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3545,10 +3545,10 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zod-to-json-schema@3.19.1:
-  version "3.19.1"
-  resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.19.1.tgz#10160724c3749c9c3b0a86ce07f18714e6fa25d3"
-  integrity sha512-yZiMqANy17jBPm5F71srrMJIpHeHgwkjIAhxGIRzlwguvipeQ4x77tJeXbowXljn7r8zZYf4Uk8E3Hqf6+sKjA==
+zod-to-json-schema@3.21.4:
+  version "3.21.4"
+  resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.21.4.tgz#de97c5b6d4a25e9d444618486cb55c0c7fb949fd"
+  integrity sha512-fjUZh4nQ1s6HMccgIeE0VP4QG/YRGPmyjO9sAh890aQKPEk3nqbfUXhMFaC+Dr5KvYBm8BCyvfpZf2jY9aGSsw==
 
 zod@3.22.4:
   version "3.22.4"


### PR DESCRIPTION
### Description

Allows schema definitions in #/components/schemas using the created "addDefinitions" function in the "OpenApiBuilder" class.

### Notes

Had to update the "zod-to-json-schema" package to make it work.  
Some conditions were added in the "makeJsonSchema" function to keep the expected results. 

### Test Results

![image](https://github.com/ecyrbe/zodios-openapi/assets/74201114/24835b59-604f-4005-8b68-b4dfa969c807)
![image](https://github.com/ecyrbe/zodios-openapi/assets/74201114/8195ba65-a92f-4467-af46-5a01f4af4d3d)
![image](https://github.com/ecyrbe/zodios-openapi/assets/74201114/a2214b44-eb4a-471a-96a1-be7798ed8e4a)
